### PR TITLE
upgrade vulnerable spring-data-redis

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -45,8 +45,7 @@
         <dependency>
             <groupId>redis.clients</groupId>
             <artifactId>jedis</artifactId>
-            <version>2.8.2</version>
-            <!-- incompatible with 2.9.0 and up: https://github.com/ozimov/embedded-redis/pull/4 -->
+            <version>2.10.2</version>
             <scope>test</scope>
         </dependency>
 

--- a/pom.xml
+++ b/pom.xml
@@ -45,14 +45,14 @@
         <dependency>
             <groupId>redis.clients</groupId>
             <artifactId>jedis</artifactId>
-            <version>2.10.2</version>
+            <version>3.8.0</version>
             <scope>test</scope>
         </dependency>
 
         <dependency>
             <groupId>org.springframework.data</groupId>
             <artifactId>spring-data-redis</artifactId>
-            <version>1.8.0.RELEASE</version>
+            <version>2.7.9</version>
             <scope>test</scope>
         </dependency>
 

--- a/src/test/java/redis/embedded/SpringDataConnectivityTest.java
+++ b/src/test/java/redis/embedded/SpringDataConnectivityTest.java
@@ -6,7 +6,6 @@ import org.junit.Test;
 import org.springframework.data.redis.connection.jedis.JedisConnectionFactory;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.data.redis.core.StringRedisTemplate;
-import redis.clients.jedis.JedisShardInfo;
 
 import java.io.IOException;
 
@@ -23,9 +22,10 @@ public class SpringDataConnectivityTest {
         redisServer = new RedisServer(6381);
         redisServer.start();
 
-        JedisShardInfo shardInfo = new JedisShardInfo("localhost", 6381);
         connectionFactory = new JedisConnectionFactory();
-        connectionFactory.setShardInfo(shardInfo);
+        connectionFactory.getStandaloneConfiguration().setHostName("localhost");
+        connectionFactory.getStandaloneConfiguration().setPort(6381);
+        connectionFactory.afterPropertiesSet();
 
         template = new StringRedisTemplate();
         template.setConnectionFactory(connectionFactory);


### PR DESCRIPTION
The currently used version of spring-data-redis provides several vulnerable dependencies:
- [org.springframework.data:spring-data-commons:1.13.0.RELEASE](https://security.snyk.io/package/maven/org.springframework.data:spring-data-commons/1.13.0.RELEASE)
- [org.springframework:spring-beans:4.3.6.RELEASE](https://security.snyk.io/package/maven/org.springframework:spring-beans/4.3.6.RELEASE)
- [org.springframework:spring-context:4.3.6.RELEASE](https://security.snyk.io/package/maven/org.springframework:spring-context/4.3.6.RELEASE)
- [org.springframework:spring-core:4.3.6.RELEASE](https://security.snyk.io/package/maven/org.springframework:spring-core/4.3.6.RELEASE)
- [org.springframework:spring-expression:4.3.6.RELEASE](https://security.snyk.io/package/maven/org.springframework:spring-expression/4.3.6.RELEASE)

This PR upgrades spring-data-redis.  It also upgrades jedis, to maintain compatibility between jedis and spring-data-redis.

Some of the necessary code adaptions are taken over from https://github.com/signalapp/embedded-redis/commit/d8f71db407ca9936678b3c69d7b895837842fdaa.