### PR TITLE
Adds support for configuring a sharded redis cluster compatible with JedisCluster

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,9 @@ RedisServer redisServer = RedisServer.newRedisServer()
 
 ## Setting up a cluster
 
-Our Embedded Redis has support for HA Redis clusters with Sentinels and master-slave replication
+Our Embedded Redis has support for:
+- HA Redis clusters with Sentinels and master-slave replication
+- Sharded Redis clusters with node replication
 
 #### Using ephemeral ports
 A simple redis integration test with Redis cluster on ephemeral ports, with setup similar to that from production would look like this:
@@ -105,6 +107,8 @@ public class SomeIntegrationTestThatRequiresRedis {
 }
 ```
 
+For an example of setting up a sharded redis cluster check out the code in `RedisShardedServerClusterTest`.
+
 #### Retrieving ports
 The above example starts Redis cluster with servers on ephemeral ports and sentinels on ports 26400, 26401 and 26402. You can later get ports of servers with ```cluster.serverPorts()```, sentinels with ```cluster.sentinelPorts()``` or all ports with ```cluster.ports()```.
 
@@ -133,3 +137,4 @@ Contributors
  * Artem Orobets ([@enisher](http://github.com/enisher))
  * Sean Simonsen ([@SeanSimonsen](http://github.com/SeanSimonsen))
  * Rob Winch ([@rwinch](http://github.com/rwinch))
+ * Cristian Badila ([@cristi-badila](http://github.com/cristi-badila))

--- a/pom.xml
+++ b/pom.xml
@@ -46,7 +46,6 @@
             <groupId>redis.clients</groupId>
             <artifactId>jedis</artifactId>
             <version>3.8.0</version>
-            <scope>test</scope>
         </dependency>
 
         <dependency>

--- a/src/main/java/redis/embedded/RedisShardedCluster.java
+++ b/src/main/java/redis/embedded/RedisShardedCluster.java
@@ -1,0 +1,176 @@
+package redis.embedded;
+
+import redis.clients.jedis.HostAndPort;
+import redis.clients.jedis.Jedis;
+import redis.clients.jedis.JedisCluster;
+import redis.embedded.core.RedisShardedClusterBuilder;
+import redis.embedded.error.RedisClusterSetupException;
+
+import java.io.IOException;
+import java.time.Duration;
+import java.util.*;
+import java.util.function.Supplier;
+import java.util.stream.IntStream;
+
+public final class RedisShardedCluster implements Redis {
+    public static final String CLUSTER_IP = "127.0.0.1";
+    private static final int MAX_NUMBER_OF_SLOTS_PER_CLUSTER = 16384;
+    private static final Duration SLEEP_DURATION = Duration.ofMillis(300);
+    private static final long SLEEP_DURATION_IN_MILLIS = SLEEP_DURATION.toMillis();
+
+    private final List<Redis> servers = new LinkedList<>();
+    private final Map<Integer, Set<Integer>> replicasPortsByMainNodePort = new LinkedHashMap<>();
+    private final Map<Integer, String> mainNodeIdsByPort = new LinkedHashMap<>();
+    private final Duration initializationTimeout;
+
+    public RedisShardedCluster(
+            final List<Redis> servers,
+            final Map<Integer, Set<Integer>> replicasPortsByMainNodePort,
+            final Duration initializationTimeout
+    ) {
+        this.servers.addAll(servers);
+        this.replicasPortsByMainNodePort.putAll(replicasPortsByMainNodePort);
+        this.initializationTimeout = initializationTimeout;
+    }
+
+    public static RedisShardedClusterBuilder newRedisCluster() { return new RedisShardedClusterBuilder(); }
+
+    @Override
+    public boolean isActive() {
+        for (final Redis redis : servers) {
+            if (!redis.isActive()) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    @Override
+    public void start() throws IOException {
+        for (final Redis redis : servers) {
+            redis.start();
+        }
+
+        linkReplicasAndShards();
+    }
+
+    @Override
+    public void stop() throws IOException {
+       for (final Redis redis : servers) {
+            redis.stop();
+        }
+    }
+
+    @Override
+    public List<Integer> ports() { return new ArrayList<>(serverPorts()); }
+
+    public List<Redis> servers() { return new LinkedList<>(servers); }
+
+    public List<Integer> serverPorts() {
+        final List<Integer> ports = new ArrayList<>();
+        for (final Redis redis : servers) {
+            ports.addAll(redis.ports());
+        }
+        return ports;
+    }
+
+    public int getPort() { return this.ports().get(0); }
+
+    private void linkReplicasAndShards() {
+        try {
+            final Set<Integer> mainNodePorts = replicasPortsByMainNodePort.keySet();
+            // Use the first node as the target to be met by all other nodes
+            final Integer clusterMeetTarget = mainNodePorts.iterator().next();
+            meetMainNodes(clusterMeetTarget);
+            setupReplicas(clusterMeetTarget);
+            waitForClusterToBeInteractReady();
+        } catch (RedisClusterSetupException e) {
+            try {
+                this.stop();
+            } catch (IOException ex) {
+                throw new RuntimeException(ex);
+            }
+            throw new RuntimeException(e);
+        }
+    }
+
+    private void meetMainNodes(final Integer clusterMeetTarget) throws RedisClusterSetupException {
+        // for every shard meet the main node (except the 1st shard) and add their slots manually
+        final List<Integer> shardsMainNodePorts = new LinkedList<>(replicasPortsByMainNodePort.keySet());
+        final int slotsPerShard = MAX_NUMBER_OF_SLOTS_PER_CLUSTER / shardsMainNodePorts.size();
+        for(int i = 0; i < shardsMainNodePorts.size(); i++) {
+            final Integer port = shardsMainNodePorts.get(i);
+            int startSlot = i * slotsPerShard;
+            int endSlot = i == shardsMainNodePorts.size() - 1
+                          ? MAX_NUMBER_OF_SLOTS_PER_CLUSTER - 1
+                          : startSlot + slotsPerShard - 1;
+            try (final Jedis jedis = new Jedis(CLUSTER_IP, port)) {
+                if(!port.equals(clusterMeetTarget)){
+                    jedis.clusterMeet(CLUSTER_IP, clusterMeetTarget);
+                }
+
+                final String nodeId = jedis.clusterMyId();
+                mainNodeIdsByPort.put(port, nodeId);
+                jedis.clusterAddSlots(IntStream.range(startSlot, endSlot + 1).toArray());
+            } catch (Exception e) {
+                throw new RedisClusterSetupException("Failed creating main node instance at port: " + port, e);
+            }
+        }
+    }
+
+    private void setupReplicas(final Integer clusterMeetTarget) throws RedisClusterSetupException {
+        for (Map.Entry<Integer, Set<Integer>> entry : replicasPortsByMainNodePort.entrySet()) {
+            final String mainNodeId = mainNodeIdsByPort.get(entry.getKey());
+            final Set<Integer> replicaPorts = entry.getValue();
+            for (Integer replicaPort : replicaPorts) {
+                try (Jedis jedis = new Jedis(CLUSTER_IP, replicaPort)) {
+                    jedis.clusterMeet(CLUSTER_IP, clusterMeetTarget);
+                    waitForNodeToAppearInCluster(jedis, mainNodeId); // make sure main node visible in cluster
+                    jedis.clusterReplicate(mainNodeId);
+                    waitForClusterToHaveStatusOK(jedis);
+                } catch (Exception e) {
+                    throw new RedisClusterSetupException("Failed adding replica instance at port: " + replicaPort, e);
+                }
+            }
+        }
+    }
+
+    private void waitForNodeToAppearInCluster(final Jedis jedis, final String nodeId) throws RedisClusterSetupException {
+        boolean nodeReady = waitForPredicateToPass(() -> jedis.clusterNodes().contains(nodeId));
+        if (!nodeReady) { throw new RedisClusterSetupException("Node was not ready before timeout"); }
+    }
+
+    private void waitForClusterToHaveStatusOK(final Jedis jedis) throws RedisClusterSetupException {
+        boolean clusterIsReady = waitForPredicateToPass(() -> jedis.clusterInfo().contains("cluster_state:ok"));
+        if (!clusterIsReady) { throw new RedisClusterSetupException("Cluster did not have status OK before timeout"); }
+    }
+
+    private void waitForClusterToBeInteractReady() throws RedisClusterSetupException {
+        boolean clusterIsReady = waitForPredicateToPass(() -> {
+            try (JedisCluster jc = new JedisCluster(new HostAndPort(CLUSTER_IP, getPort()))) {
+                jc.get("someKey");
+                return true;
+            } catch (Exception e) {
+                // ignore
+                return false;
+            }
+        });
+        if (!clusterIsReady) { throw new RedisClusterSetupException("Cluster was not stable before timeout"); }
+    }
+
+    private boolean waitForPredicateToPass(final Supplier<Boolean> predicate) throws RedisClusterSetupException {
+        int waited = 0;
+        long maxWaitInMillis = initializationTimeout.toMillis();
+        boolean result = predicate.get();
+        while (!result && waited < maxWaitInMillis) {
+            try {
+                Thread.sleep(SLEEP_DURATION_IN_MILLIS);
+            } catch (InterruptedException e) {
+                throw new RedisClusterSetupException("Interrupted while waiting", e);
+            }
+            waited += SLEEP_DURATION_IN_MILLIS;
+            result = predicate.get();
+        }
+        return result;
+    }
+}

--- a/src/main/java/redis/embedded/core/PortProvider.java
+++ b/src/main/java/redis/embedded/core/PortProvider.java
@@ -7,6 +7,13 @@ import java.util.Iterator;
 import java.util.concurrent.atomic.AtomicInteger;
 
 public interface PortProvider {
+    //Redis uses a cluster bus port as the first node port + 10000, so we need to make sure we use ports lower than
+    // 55535 to ensure we always get a valid cluster bus port. We chose 50000 in order to have a safe margin.
+    // Theoretically we could use the "cluster-port" as documented here:
+    // https://redis.io/docs/reference/cluster-spec/#the-cluster-bus
+    // however adding that config to the redis server currently results in an error when running on Windows.
+    int REDIS_CLUSTER_MAX_PORT_EXCLUSIVE = 50000;
+
     int get();
 
     static PortProvider newEphemeralPortProvider() {
@@ -17,6 +24,15 @@ public interface PortProvider {
             } catch (IOException e) {
                 throw new IllegalArgumentException("Could not provide ephemeral port", e);
             }
+        };
+    }
+
+    static PortProvider newEphemeralPortProviderInRedisClusterRange() {
+        final PortProvider ephemeralPortProvider = newEphemeralPortProvider();
+        return () -> {
+            int port = ephemeralPortProvider.get();
+            while (port > REDIS_CLUSTER_MAX_PORT_EXCLUSIVE) { port = ephemeralPortProvider.get();}
+            return port;
         };
     }
 
@@ -32,9 +48,9 @@ public interface PortProvider {
     static PortProvider newSequencePortProvider() {
         return newSequencePortProvider(26379);
     }
+
     static PortProvider newSequencePortProvider(final int start) {
         final AtomicInteger currentPort = new AtomicInteger(start);
         return currentPort::getAndIncrement;
     }
-
 }

--- a/src/main/java/redis/embedded/core/RedisShardedClusterBuilder.java
+++ b/src/main/java/redis/embedded/core/RedisShardedClusterBuilder.java
@@ -1,0 +1,92 @@
+package redis.embedded.core;
+
+import redis.embedded.Redis;
+import redis.embedded.RedisServer;
+import redis.embedded.RedisShardedCluster;
+import redis.embedded.model.Shard;
+
+import java.io.IOException;
+import java.time.Duration;
+import java.util.*;
+
+import static redis.embedded.core.PortProvider.*;
+
+public final class RedisShardedClusterBuilder {
+    private static final Duration DEFAULT_INITIALIZATION_TIMEOUT = Duration.ofSeconds(20);
+
+    private RedisServerBuilder serverBuilder = new RedisServerBuilder();
+    private PortProvider shardPortProvider = newSequencePortProvider(6379);
+    private Duration initializationTimeout = DEFAULT_INITIALIZATION_TIMEOUT;
+    private final List<Shard> shards = new LinkedList<>();
+    private final Map<Integer, Set<Integer>> replicasPortsByMainNodePort = new LinkedHashMap<>();
+
+    public RedisShardedClusterBuilder withServerBuilder(final RedisServerBuilder serverBuilder) {
+        this.serverBuilder = serverBuilder;
+        return this;
+    }
+
+    public RedisShardedClusterBuilder serverPorts(final Collection<Integer> ports) {
+        this.shardPortProvider = newPredefinedPortProvider(ports);
+        return this;
+    }
+
+    public RedisShardedClusterBuilder initializationTimeout(final Duration initializationTimeout) {
+        this.initializationTimeout = initializationTimeout;
+        return this;
+    }
+
+    public RedisShardedClusterBuilder ephemeralServers() {
+        this.shardPortProvider = newEphemeralPortProviderInRedisClusterRange();
+        return this;
+    }
+
+    public RedisShardedClusterBuilder ephemeral() {
+        ephemeralServers();
+        return this;
+    }
+    public RedisShardedClusterBuilder shard(final String name, final int replicaCount) {
+        this.shards.add(new Shard(name, replicaCount, this.shardPortProvider));
+        return this;
+    }
+
+    public RedisShardedCluster build() throws IOException {
+        final List<Redis> servers = buildServers();
+        return new RedisShardedCluster(servers, replicasPortsByMainNodePort, initializationTimeout);
+    }
+
+    private List<Redis> buildServers() throws IOException {
+        final List<Redis> servers = new ArrayList<>();
+        for (final Shard shard : shards) {
+            servers.add(buildMainNode(shard));
+            servers.addAll(buildReplicas(shard));
+        }
+        return servers;
+    }
+
+    private List<RedisServer> buildReplicas(final Shard shard) throws IOException {
+        final List<RedisServer> replicas = new ArrayList<>();
+        final Set<Integer> replicaPorts = replicasPortsByMainNodePort.get(shard.mainNodePort);
+        for (final Integer replicaPort : shard.replicaPorts) {
+            replicaPorts.add(replicaPort);
+            serverBuilder.reset();
+            serverBuilder.port(replicaPort);
+            serverBuilder.setting("cluster-enabled yes");
+            serverBuilder.setting("cluster-config-file nodes-replica-" + replicaPort + ".conf");
+            serverBuilder.setting("cluster-node-timeout 5000");
+            serverBuilder.setting("appendonly no");
+            final RedisServer slave = serverBuilder.build();
+            replicas.add(slave);
+        }
+        return replicas;
+    }
+
+    private RedisServer buildMainNode(final Shard shard) throws IOException {
+        replicasPortsByMainNodePort.put(shard.mainNodePort, new HashSet<>());
+        serverBuilder.reset();
+        serverBuilder.setting("cluster-enabled yes");
+        serverBuilder.setting("cluster-config-file nodes-main-" + shard.mainNodePort + ".conf");
+        serverBuilder.setting("cluster-node-timeout 5000");
+        serverBuilder.setting("appendonly no");
+        return serverBuilder.port(shard.mainNodePort).build();
+    }
+}

--- a/src/main/java/redis/embedded/error/RedisClusterSetupException.java
+++ b/src/main/java/redis/embedded/error/RedisClusterSetupException.java
@@ -1,0 +1,7 @@
+package redis.embedded.error;
+
+public class RedisClusterSetupException extends Exception {
+    public RedisClusterSetupException(final String message) { super(message); }
+
+    public RedisClusterSetupException(final String message, final Throwable cause) { super(message, cause); }
+}

--- a/src/main/java/redis/embedded/model/Shard.java
+++ b/src/main/java/redis/embedded/model/Shard.java
@@ -1,0 +1,20 @@
+package redis.embedded.model;
+
+import redis.embedded.core.PortProvider;
+
+import java.util.LinkedList;
+import java.util.List;
+
+public final class Shard {
+    public final String name;
+    public final int mainNodePort;
+    public final List<Integer> replicaPorts = new LinkedList<>();
+
+    public Shard(final String name, int replicaCount, final PortProvider provider) {
+        this.name = name;
+        this.mainNodePort = provider.get();
+        while (replicaCount-- > 0) {
+            this.replicaPorts.add(provider.get());
+        }
+    }
+}

--- a/src/test/java/redis/embedded/RedisShardedClusterTest.java
+++ b/src/test/java/redis/embedded/RedisShardedClusterTest.java
@@ -1,0 +1,54 @@
+package redis.embedded;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import redis.clients.jedis.HostAndPort;
+import redis.clients.jedis.JedisCluster;
+
+import java.io.IOException;
+
+import static org.junit.Assert.assertEquals;
+import static redis.embedded.RedisShardedCluster.CLUSTER_IP;
+
+public class RedisShardedClusterTest {
+	private RedisShardedCluster cluster;
+
+    @Before
+    public void setUp() throws IOException {
+		cluster = RedisShardedCluster.newRedisCluster()
+									   .shard("master1", 1)
+									   .shard("master2", 1)
+									   .shard("master3", 1)
+									   .build();
+		cluster.start();
+    }
+
+    @Test
+    public void testSimpleOperationsAfterClusterStart() {
+        try (JedisCluster jc = new JedisCluster(new HostAndPort(CLUSTER_IP, cluster.getPort()))) {
+            jc.set("somekey", "somevalue");
+            assertEquals("the value should be equal", "somevalue", jc.get("somekey"));
+        }
+    }
+
+	@Test
+	public void testSimpleOperationsAfterClusterWithEphemeralPortsStart() throws IOException {
+		cluster.stop();
+		cluster = RedisShardedCluster.newRedisCluster().ephemeral()
+									 .shard("master1", 1)
+									 .shard("master2", 1)
+									 .shard("master3", 1)
+									 .build();
+		cluster.start();
+		try (JedisCluster jc = new JedisCluster(new HostAndPort(CLUSTER_IP, cluster.getPort()))) {
+			jc.set("somekey", "somevalue");
+			assertEquals("the value should be equal", "somevalue", jc.get("somekey"));
+		}
+	}
+
+    @After
+    public void tearDown() throws Exception {
+        cluster.stop();
+    }
+}


### PR DESCRIPTION
**Why**:
Currently, I'm running embedded-redis in the test environment for a project which connects to a sharded redis cluster. In order to have an experience as close to the production one in the test environment, I needed embedded-redis to configure the started servers as a sharded cluster and as such be able to connect an instance of the `JedisCluster` client to it.

**How**:
The work I did was mostly in two new classes: `RedisShardedClusterBuilder`,  `RedisShardedCluster` which allow the parametriaztion of a new sharded cluster, and the starting/configuring/stopping of it. I opted to go with adding new classes since I didn't want to introduce invalid configuration paths in the existing classes. The "newness" of what `RedisShardedCluster` does is that it starts all Redis instances as "master" nodes initially and connects them to each other using the `CLUSTER MEET` command. It then connects all the replicas to their corresponding "main" nodes using the `CLUSTER REPLICATE` command.

The main configuration logic was inspired by the work done by [aarondwi](https://github.com/aarondwi) in his fork of the original project here: https://github.com/aarondwi/embedded-redis-cluster#using-ephemeral-ports.

**Notes**
There are two noticeable changes:
- in order to configure the servers, I had to change the `jedis` dependency to no longer be used only for tests since now it's used in the bootstrap logic
- I added a restriction to the ephemeral ports provider used for the sharded cluster so as to only use ports smaller than `50000`. This is due to the fact that the Redis cluster will open/use a bus communication port that is the port of the first node + 10000. This can result in invalid port values if not checked (over 65535)