### PR TITLE
Add stdout listener before waiting startup

### DIFF
--- a/src/main/java/redis/embedded/RedisInstance.java
+++ b/src/main/java/redis/embedded/RedisInstance.java
@@ -42,9 +42,10 @@ public abstract class RedisInstance implements Redis {
             addShutdownHook("RedisInstanceCleaner", checkedToRuntime(this::stop));
             if (serrListener != null)
                 newDaemonThread(() -> logStream(process.getErrorStream(), serrListener)).start();
-            awaitServerReady(process, readyPattern, soutListener);
             if (soutListener != null)
                 newDaemonThread(() -> logStream(process.getInputStream(), soutListener)).start();
+
+            awaitServerReady(process, readyPattern, soutListener);
 
             active = true;
         } catch (final IOException e) {


### PR DESCRIPTION
Add stdout listener before waiting startup. In some cases, errors happens in redis in stdout. We must attach the stdout listener before waiting for the startup message if we want to have a chance to see it.

For example, in my case, this error happens on stdout : 
``` /tmp/redis-16804944963916210717/redis-server-6.2.6-v5-linux-amd64: error while loading shared libraries: libssl.so.3: cannot open shared object file: No such file or directory```
